### PR TITLE
#18, Refactor FilterService to extend GraphQueryService

### DIFF
--- a/core/services/filter_service.py
+++ b/core/services/filter_service.py
@@ -1,9 +1,16 @@
 # core/services/filter_service.py
+"""
+    FilterService — filters graph nodes based on attribute queries.
 
+    Extends ``GraphQueryService[str]`` (Template Method + Genericity).
+"""
 import re
+from typing import Set
+
 from api.api.models.graph import Graph
 from api.api.models.node import Node
 from api.api.types import TypeValidator
+from .base_service import GraphQueryService
 from .exceptions import FilterParseError, FilterTypeError
 
 # Regex: attribute  operator  value
@@ -11,27 +18,44 @@ from .exceptions import FilterParseError, FilterTypeError
 _FILTER_PATTERN = re.compile(r'^\s*(\w+)\s*(==|!=|>=|<=|>(?![><=!])|<(?![><=!]))\s*(.+)\s*$')
 
 
-class FilterService:
+class FilterService(GraphQueryService[str]):
     """
     Filters graph nodes based on a query of the form:
         <attribute_name> <comparator> <value>
+
+    Extends ``GraphQueryService[str]`` — the generic base provides
+    the Template Method ``execute(graph, query)`` which calls:
+        1. ``_validate_query(query)``
+        2. ``_find_matching_nodes(graph, query)``
+        3. ``graph.get_subgraph_by_nodes(matching_ids)``
     """
+
+    # ── Public convenience method (backward-compatible) ──────────
 
     def filter(self, graph: Graph, query: str) -> Graph:
         """
+        Convenience wrapper around the generic ``execute()``.
+
         :param graph: Input graph to filter
         :param query: Filter query string (e.g. "Age >= 30")
         :return: Subgraph containing only matching nodes
         :raises FilterParseError: If query is None, empty, or has invalid syntax
         :raises FilterTypeError: If the value cannot be compared with the attribute type
         """
+        return self.execute(graph, query)
+
+    # ── Template Method hooks (from GraphQueryService[str]) ──────
+
+    def _validate_query(self, query: str) -> None:
+        """Validate that the filter query is non-empty and syntactically correct."""
         if query is None or not query.strip():
             raise FilterParseError("Filter query cannot be empty.")
-
-        match = _FILTER_PATTERN.match(query)
-        if not match:
+        if not _FILTER_PATTERN.match(query):
             raise FilterParseError("Invalid filter format.")
 
+    def _find_matching_nodes(self, graph: Graph, query: str) -> Set[str]:
+        """Return IDs of all nodes whose attribute satisfies the filter."""
+        match = _FILTER_PATTERN.match(query)
         attr_name = match.group(1)
         operator = match.group(2)
         target_value_str = match.group(3).strip()
@@ -40,8 +64,7 @@ class FilterService:
         for node in graph.get_all_nodes():
             if self._evaluate_node(node, attr_name, operator, target_value_str):
                 matching_ids.add(node.node_id)
-
-        return graph.get_subgraph_by_nodes(matching_ids)
+        return matching_ids
 
     def _evaluate_node(self, node: Node, attr_name: str,
                        operator: str, target_value_str: str) -> bool:


### PR DESCRIPTION

This pull request refactors the `FilterService` to use a generic template method pattern by extending `GraphQueryService[str]`, improving code structure and maintainability. It also clarifies the responsibilities of each method and ensures backward compatibility with the existing `filter()` method.

Refactor to use Template Method pattern:

* `FilterService` now inherits from `GraphQueryService[str]`, utilizing its `execute()` template method to structure the filtering process, which includes query validation, node matching, and subgraph extraction.
* The `_validate_query` and `_find_matching_nodes` methods are implemented as hooks for the template method, separating concerns and making the logic clearer. [[1]](diffhunk://#diff-188814f0a3d1f365bcd65264f060bcd74aec439a6972898ed8a00d5a2b18b540R2-R58) [[2]](diffhunk://#diff-188814f0a3d1f365bcd65264f060bcd74aec439a6972898ed8a00d5a2b18b540L43-R67)

Backward compatibility and code clarity:

* The public `filter()` method is retained as a convenience wrapper around the new `execute()` method, ensuring existing code using `filter()` continues to work.
* The `_find_matching_nodes` method now returns a set of matching node IDs instead of a subgraph, delegating subgraph construction to the template method for better separation of concerns.

Documentation improvements:

* Added clear docstrings to the class and methods, describing the new structure and usage.

Closes #18 