### PR TITLE
#19, Refactor SearchService to extend GraphQueryService

### DIFF
--- a/core/services/search_service.py
+++ b/core/services/search_service.py
@@ -1,53 +1,76 @@
 # core/services/search_service.py
+"""
+    SearchService — searches graph nodes by attribute name or value.
+
+    Extends ``GraphQueryService[str]`` (Template Method + Genericity).
+"""
 import re
+from typing import Set
+
 from api.api.models.graph import Graph
+from .base_service import GraphQueryService
 from .exceptions import SearchParseError
 
 # Regex za "Name=Vedran" ili "City=New York"
 _VALUE_PATTERN = re.compile(r'^(\w+)=(.+)$')
 
 
-class SearchService:
+class SearchService(GraphQueryService[str]):
     """
     Two search modes:
     - By attribute name:  "Age"         → nodes that have attribute named 'Age'
     - By attribute value: "Name=Vedran" → nodes where attribute 'Name' contains 'Vedran'
+
+    Extends ``GraphQueryService[str]`` — the generic base provides
+    the Template Method ``execute(graph, query)`` which calls:
+        1. ``_validate_query(query)``
+        2. ``_find_matching_nodes(graph, query)``
+        3. ``graph.get_subgraph_by_nodes(matching_ids)``
     """
+
+    # ── Public convenience method (backward-compatible) ──────────
 
     def search(self, graph: Graph, query: str) -> Graph:
         """
+        Convenience wrapper around the generic ``execute()``.
+
         :param graph: Input graph
         :param query: 'AttrName' or 'AttrName=value'
         :return: Subgraph of matching nodes
         :raises SearchParseError: If query is empty
         """
+        return self.execute(graph, query)
+
+    # ── Template Method hooks (from GraphQueryService[str]) ──────
+
+    def _validate_query(self, query: str) -> None:
+        """Validate that the search query is non-empty."""
         if not query or not query.strip():
             raise SearchParseError("Search query cannot be empty.")
 
+    def _find_matching_nodes(self, graph: Graph, query: str) -> Set[str]:
+        """Return IDs of all nodes matching the search query."""
         query = query.strip()
         match = _VALUE_PATTERN.match(query)
 
         if match:
-            # Mode 2: "Name=Vedran" — search by attribute VALUE
             attr_name = match.group(1)
             search_value = match.group(2).strip()
-            return self._search_by_value(graph, attr_name, search_value)
+            return self._find_by_value(graph, attr_name, search_value)
         else:
-            # Mode 1: "Age" — search by attribute NAME
-            return self._search_by_name(graph, query)
+            return self._find_by_name(graph, query)
 
-    def _search_by_name(self, graph: Graph, attr_name: str) -> Graph:
-        """Return nodes that have an attribute with this name (case-insensitive)."""
+    def _find_by_name(self, graph: Graph, attr_name: str) -> Set[str]:
+        """Return IDs of nodes that have an attribute with this name (case-insensitive)."""
         attr_lower = attr_name.lower()
-        matching_ids = {
+        return {
             node.node_id
             for node in graph.get_all_nodes()
             if any(attr_lower in key.lower() for key in node.attributes.keys())
         }
-        return graph.get_subgraph_by_nodes(matching_ids)
 
-    def _search_by_value(self, graph: Graph, attr_name: str, value: str) -> Graph:
-        """Return nodes where attribute 'attr_name' contains 'value' (case-insensitive)."""
+    def _find_by_value(self, graph: Graph, attr_name: str, value: str) -> Set[str]:
+        """Return IDs of nodes where attribute 'attr_name' contains 'value' (case-insensitive)."""
         attr_lower = attr_name.lower()
         value_lower = value.lower()
 
@@ -59,4 +82,4 @@ class SearchService:
                         matching_ids.add(node.node_id)
                         break
 
-        return graph.get_subgraph_by_nodes(matching_ids)
+        return matching_ids


### PR DESCRIPTION
This pull request refactors the `SearchService` to extend a new generic base class, `GraphQueryService[str]`, implementing the template method pattern for searching graph nodes by attribute name or value. The service now separates query validation and node matching logic into dedicated methods, returning sets of node IDs rather than subgraphs within internal methods. The public interface remains backward-compatible via the `search()` method.

Key changes include:

**Refactoring and Design Improvements:**

* `SearchService` now inherits from `GraphQueryService[str]`, leveraging a template method pattern for query execution and making the codebase more modular and extensible.
* The internal search methods (`_find_by_name` and `_find_by_value`) now return sets of node IDs instead of subgraphs, delegating subgraph construction to the base class. [[1]](diffhunk://#diff-097fc9c83f92f79163d3cfc036bfef11905c175ea30a62ba1cbd2f0a3a578db7R2-R73) [[2]](diffhunk://#diff-097fc9c83f92f79163d3cfc036bfef11905c175ea30a62ba1cbd2f0a3a578db7L62-R85)

**API and Method Changes:**

* Introduced `_validate_query`, `_find_matching_nodes`, `_find_by_name`, and `_find_by_value` methods to better structure the search logic and improve code clarity.
* The public `search()` method remains as a backward-compatible wrapper around the new `execute()` method provided by the base class.

**Documentation:**

* Added class-level and method-level docstrings to clarify the service’s behavior, usage, and extension points.

Closes #19