### PR TITLE
#30 Add workspace persistence with save/load support

### DIFF
--- a/core/graph_platform/core.py
+++ b/core/graph_platform/core.py
@@ -276,6 +276,40 @@ class GraphPlatform:
         """Return metadata dicts for all workspaces."""
         return [ws.to_dict() for ws in self._workspaces.values()]
 
+    # ── Workspace persistence ────────────────────────────────────
+
+    def save_workspace(self, directory: str,
+                       workspace_id: Optional[str] = None) -> str:
+        """
+        Save a workspace to disk for later resumption.
+
+        Args:
+            directory:    Target directory for the JSON file.
+            workspace_id: Workspace to save (defaults to active).
+
+        Returns:
+            Absolute path of the saved file.
+        """
+        ws = self._resolve_workspace(workspace_id)
+        return ws.save(directory)
+
+    def load_workspace(self, file_path: str) -> Workspace:
+        """
+        Load a workspace from a previously saved JSON file.
+
+        Args:
+            file_path: Path to the workspace JSON file.
+
+        Returns:
+            The restored and activated Workspace.
+        """
+        ws = Workspace.load(file_path)
+        self._workspaces[ws.workspace_id] = ws
+        self._active_workspace_id = ws.workspace_id
+        self._notify(EVENT_WORKSPACE_CREATED, workspace=ws)
+        logger.info("Workspace loaded from %s", file_path)
+        return ws
+
     # ── Graph operations on active workspace ─────────────────────
 
     def filter_graph(self, query: str,

--- a/core/graph_platform/workspace.py
+++ b/core/graph_platform/workspace.py
@@ -11,11 +11,18 @@
         • original_graph  – the unmodified graph from the data source
         • current_graph   – the graph after all applied operations
         • history         – stack of intermediate graph snapshots
+
+    Persistence (optional feature)
+    ──────────────────────────────
+    ``save()`` / ``load()`` enable persistent workspace storage so a
+    user can resume a previous session.
 """
+import json
 import uuid
 import logging
 from copy import deepcopy
-from typing import List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from api.models.graph import Graph
 
@@ -170,6 +177,81 @@ class Workspace:
             'edges': self._current_graph.get_number_of_edges(),
             'history_depth': self.history_depth,
         }
+
+    # ── Persistence (optional feature) ──────────────────────────────
+
+    def save(self, directory: str) -> str:
+        """
+        Persist the workspace to disk so the user can resume later.
+
+        Creates a JSON file containing workspace metadata **and** the
+        serialized original + current graphs.
+
+        Args:
+            directory: Directory to write the workspace file into.
+
+        Returns:
+            Absolute path to the saved file.
+        """
+        from services.serialization_service import GraphSerializer
+
+        serializer = GraphSerializer()
+        data: Dict[str, Any] = {
+            'workspace_id': self.workspace_id,
+            'name': self.name,
+            'data_source': self.data_source,
+            'file_path': self.file_path,
+            'max_history': self._max_history,
+            'original_graph': serializer.serialize(self._original_graph),
+            'current_graph': serializer.serialize(self._current_graph),
+            'history': [serializer.serialize(g) for g in self._history],
+        }
+
+        dir_path = Path(directory)
+        dir_path.mkdir(parents=True, exist_ok=True)
+        file_path = dir_path / f"{self.workspace_id}.json"
+
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2, default=str)
+
+        logger.info("Workspace %s saved to %s", self.workspace_id[:8], file_path)
+        return str(file_path)
+
+    @classmethod
+    def load(cls, file_path: str) -> 'Workspace':
+        """
+        Restore a workspace from a previously saved JSON file.
+
+        Args:
+            file_path: Path to the saved workspace JSON file.
+
+        Returns:
+            A fully restored Workspace instance with history.
+        """
+        from services.serialization_service import GraphSerializer
+
+        serializer = GraphSerializer()
+
+        with open(file_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        original_graph = serializer.deserialize(data['original_graph'])
+        current_graph = serializer.deserialize(data['current_graph'])
+
+        ws = cls.__new__(cls)
+        ws.workspace_id = data['workspace_id']
+        ws.name = data['name']
+        ws.data_source = data.get('data_source', '')
+        ws.file_path = data.get('file_path', '')
+        ws._original_graph = original_graph
+        ws._current_graph = current_graph
+        ws._max_history = data.get('max_history', 50)
+        ws._history = [serializer.deserialize(g) for g in data.get('history', [])]
+        ws._filter_service = FilterService()
+        ws._search_service = SearchService()
+
+        logger.info("Workspace %s loaded from %s", ws.workspace_id[:8], file_path)
+        return ws
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
This pull request adds support for persistent workspace storage, allowing users to save and later resume their graph workspaces. The main changes introduce new methods for saving and loading workspaces as JSON files, update the workspace class to handle serialization, and integrate these features into the core platform API.

**Workspace persistence features:**

* Added `save_workspace` and `load_workspace` methods to `core.py` to enable saving and restoring workspaces from disk, updating the active workspace and notifying listeners when a workspace is loaded.
* Implemented `save` and `load` methods in the `Workspace` class to serialize all relevant workspace data (including graphs and history) to and from JSON files, using the `GraphSerializer` service for graph serialization.

**Documentation and typing updates:**

* Updated the `Workspace` class docstring to document the new persistence feature and its API.
* Extended type annotations in `workspace.py` to support new persistence logic.

Closes #30 