### PR TITLE
#43 Fixed tests for persistence

### DIFF
--- a/tests/core_test/test_persistence.py
+++ b/tests/core_test/test_persistence.py
@@ -136,6 +136,7 @@ class TestWorkspaceLoad:
         file_path = ws1.save(str(tmp_path))
         ws2 = Workspace.load(file_path)
         n1 = ws2.current_graph.get_node("n1")
+        assert n1 is not None
         assert n1.get_attribute("Name") == "Alice"
         assert n1.get_attribute("Age") == 30
 
@@ -144,6 +145,7 @@ class TestWorkspaceLoad:
         file_path = ws1.save(str(tmp_path))
         ws2 = Workspace.load(file_path)
         n1 = ws2.current_graph.get_node("n1")
+        assert n1 is not None
         assert n1.get_attribute("Born") == date(1994, 3, 12)
 
     def test_load_restores_edge_direction(self, tmp_path):
@@ -152,6 +154,8 @@ class TestWorkspaceLoad:
         ws2 = Workspace.load(file_path)
         e1 = ws2.current_graph.get_edge("e1")
         e2 = ws2.current_graph.get_edge("e2")
+        assert e1 is not None
+        assert e2 is not None
         assert e1.is_directed() is True
         assert e2.is_directed() is False
 


### PR DESCRIPTION
This pull request adds additional assertions to improve the robustness of existing persistence tests. Specifically, it ensures that nodes and edges loaded from disk are not `None` before their attributes or methods are accessed.

Improvements to test robustness:

* Added assertions to check that nodes loaded with `get_node` are not `None` before accessing their attributes in `test_load_restores_node_attributes` and `test_load_restores_date_attributes` (`tests/core_test/test_persistence.py`). [[1]](diffhunk://#diff-4b616f8df5e91ea93d8830febbf65cb6d478bdeb201510a00f58ef0e6c85cf7eR139) [[2]](diffhunk://#diff-4b616f8df5e91ea93d8830febbf65cb6d478bdeb201510a00f58ef0e6c85cf7eR148)
* Added assertions to check that edges loaded with `get_edge` are not `None` before checking their direction in `test_load_restores_edge_direction` (`tests/core_test/test_persistence.py`).

Closes #43 