### PR TITLE
#67 feat: add setup and run scripts for Ubuntu/Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,20 @@
+# ─────────────────────────────────────────────────────────
+# Graph Structure Visualizer — Python dependencies
+# ─────────────────────────────────────────────────────────
+# Install with: pip install -r requirements.txt
+#
+# Note: The project's own packages (api, core, plugins) are
+#       installed separately via their setup.py files.
+#       This file lists only third-party dependencies.
+# ─────────────────────────────────────────────────────────
+
+# Web frameworks
+Django>=4.2
+Flask>=3.0
+
+# Data source plugin dependencies
+rdflib>=6.0.0
+lxml>=5.0.0
+
+# Testing
+pytest>=7.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════
+# run.sh — Graph Structure Visualizer — Ubuntu/Linux Runner
+# ═══════════════════════════════════════════════════════════
+#
+# Activates the virtual environment and starts either the
+# Django or Flask development server.
+#
+# Usage:
+#   ./run.sh              (defaults to Django)
+#   ./run.sh django       (Django on port 8000)
+#   ./run.sh flask        (Flask  on port 5001)
+#   ./run.sh test         (run pytest test suite)
+#   ./run.sh reinstall    (reinstall all components)
+#
+# ═══════════════════════════════════════════════════════════
+
+set -e
+
+# ── Colors ───────────────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+header()  { echo -e "${CYAN}$1${NC}"; }
+
+# ── Resolve paths ────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+
+# ── Check venv exists ───────────────────────────────────
+if [ ! -d "$VENV_DIR" ]; then
+    error "Virtual environment not found at $VENV_DIR"
+    error "Run  ./setup.sh  first to create the environment."
+    exit 1
+fi
+
+# ── Activate venv ───────────────────────────────────────
+source "$VENV_DIR/bin/activate"
+
+# ── Parse argument ──────────────────────────────────────
+MODE="${1:-django}"
+MODE=$(echo "$MODE" | tr '[:upper:]' '[:lower:]')
+
+case "$MODE" in
+
+    # ────────────────────────────────────────────────────
+    django)
+        header ""
+        header "═══════════════════════════════════════════"
+        header "  Starting Django Development Server"
+        header "  http://127.0.0.1:8000/"
+        header "═══════════════════════════════════════════"
+        header ""
+
+        cd "$PROJECT_ROOT/graph_django_app"
+
+        # Run migrations silently in case of first run
+        python manage.py migrate --run-syncdb 2>/dev/null || true
+
+        info "Server starting on http://127.0.0.1:8000/"
+        info "Press Ctrl+C to stop."
+        echo ""
+
+        python manage.py runserver 0.0.0.0:8000
+        ;;
+
+    # ────────────────────────────────────────────────────
+    flask)
+        header ""
+        header "═══════════════════════════════════════════"
+        header "  Starting Flask Development Server"
+        header "  http://127.0.0.1:5001/"
+        header "═══════════════════════════════════════════"
+        header ""
+
+        cd "$PROJECT_ROOT/graph_flask_app"
+
+        info "Server starting on http://127.0.0.1:5001/"
+        info "Press Ctrl+C to stop."
+        echo ""
+
+        python app.py
+        ;;
+
+    # ────────────────────────────────────────────────────
+    test|tests)
+        header ""
+        header "═══════════════════════════════════════════"
+        header "  Running Test Suite"
+        header "═══════════════════════════════════════════"
+        header ""
+
+        cd "$PROJECT_ROOT"
+        pytest tests/ -v --tb=short
+        ;;
+
+    # ────────────────────────────────────────────────────
+    reinstall)
+        header ""
+        header "═══════════════════════════════════════════"
+        header "  Reinstalling All Components"
+        header "═══════════════════════════════════════════"
+        header ""
+
+        info "Uninstalling old packages..."
+        pip uninstall -y graph-visualizer-api graph-visualizer-core \
+            data-source-plugin-json data-source-plugin-xml \
+            data-source-plugin-rdf-turtle \
+            simple-visualizer block-visualizer 2>/dev/null || true
+
+        # Clean build artifacts
+        info "Cleaning build artifacts..."
+        find "$PROJECT_ROOT" -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+        find "$PROJECT_ROOT" -type d -name "build" -exec rm -rf {} + 2>/dev/null || true
+        find "$PROJECT_ROOT" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+
+        info "Reinstalling all components..."
+        pip install -e "$PROJECT_ROOT/api"
+        pip install -e "$PROJECT_ROOT/core"
+        pip install -e "$PROJECT_ROOT/data_source_plugin_json"
+        pip install -e "$PROJECT_ROOT/data_source_plugin_xml"
+        pip install -e "$PROJECT_ROOT/data_source_plugin_rdf"
+        pip install -e "$PROJECT_ROOT/simple_visualizer"
+        pip install -e "$PROJECT_ROOT/block_visualizer"
+
+        info ""
+        info "Reinstallation complete!"
+        info "Installed packages:"
+        pip list --format=columns | grep -iE "graph-visualizer|data-source|simple-visualizer|block-visualizer"
+        ;;
+
+    # ────────────────────────────────────────────────────
+    *)
+        echo ""
+        echo "Usage: ./run.sh [django|flask|test|reinstall]"
+        echo ""
+        echo "  django      Start Django development server (port 8000) [default]"
+        echo "  flask       Start Flask development server  (port 5001)"
+        echo "  test        Run the pytest test suite"
+        echo "  reinstall   Uninstall & reinstall all project components"
+        echo ""
+        exit 1
+        ;;
+esac

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════
+# setup.sh — Graph Structure Visualizer — Ubuntu/Linux Setup
+# ═══════════════════════════════════════════════════════════
+#
+# Creates a virtual environment, installs all third-party
+# dependencies, and installs every project component
+# (API, Core/Platform, all Data Source plugins, both
+# Visualizer plugins) in development mode.
+#
+# Usage:
+#   chmod +x setup.sh
+#   ./setup.sh
+#
+# After setup completes, use  ./run.sh  to start the server.
+# ═══════════════════════════════════════════════════════════
+
+set -e  # Exit immediately on error
+
+# ── Colors for output ────────────────────────────────────
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $1"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# ── Resolve project root (directory containing this script) ──
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+
+info "Project root: $PROJECT_ROOT"
+
+# ── 1. Check Python is installed ────────────────────────────
+if command -v python3 &>/dev/null; then
+    PYTHON=python3
+elif command -v python &>/dev/null; then
+    PYTHON=python
+else
+    error "Python is not installed. Please install Python 3.8+ first."
+    error "  Ubuntu/Debian:  sudo apt install python3 python3-venv python3-pip"
+    exit 1
+fi
+
+PY_VERSION=$($PYTHON --version 2>&1)
+info "Using $PY_VERSION"
+
+# ── 2. Ensure python3-venv is available ─────────────────────
+if ! $PYTHON -m venv --help &>/dev/null; then
+    warn "python3-venv is not installed. Attempting to install..."
+    sudo apt update && sudo apt install -y python3-venv
+fi
+
+# ── 3. Create virtual environment ──────────────────────────
+if [ -d "$VENV_DIR" ]; then
+    warn "Virtual environment already exists at $VENV_DIR"
+    read -p "  Recreate it? [y/N]: " RECREATE
+    if [[ "$RECREATE" =~ ^[Yy]$ ]]; then
+        info "Removing old virtual environment..."
+        rm -rf "$VENV_DIR"
+        info "Creating new virtual environment..."
+        $PYTHON -m venv "$VENV_DIR"
+    fi
+else
+    info "Creating virtual environment at $VENV_DIR ..."
+    $PYTHON -m venv "$VENV_DIR"
+fi
+
+# ── 4. Activate virtual environment ────────────────────────
+info "Activating virtual environment..."
+source "$VENV_DIR/bin/activate"
+
+# ── 5. Upgrade pip & setuptools ────────────────────────────
+info "Upgrading pip and setuptools..."
+pip install --upgrade pip setuptools wheel
+
+# ── 6. Install third-party dependencies ────────────────────
+info "Installing third-party dependencies from requirements.txt ..."
+pip install -r "$PROJECT_ROOT/requirements.txt"
+
+# ── 7. Install project components (development mode) ───────
+# Order matters: API first, then Core, then plugins.
+
+info "Installing API library..."
+pip install -e "$PROJECT_ROOT/api"
+
+info "Installing Core platform..."
+pip install -e "$PROJECT_ROOT/core"
+
+info "Installing JSON Data Source plugin..."
+pip install -e "$PROJECT_ROOT/data_source_plugin_json"
+
+info "Installing XML Data Source plugin..."
+pip install -e "$PROJECT_ROOT/data_source_plugin_xml"
+
+info "Installing RDF Turtle Data Source plugin..."
+pip install -e "$PROJECT_ROOT/data_source_plugin_rdf"
+
+info "Installing Simple Visualizer plugin..."
+pip install -e "$PROJECT_ROOT/simple_visualizer"
+
+info "Installing Block Visualizer plugin..."
+pip install -e "$PROJECT_ROOT/block_visualizer"
+
+# ── 8. Run Django migrations ───────────────────────────────
+info "Running Django migrations..."
+cd "$PROJECT_ROOT/graph_django_app"
+python manage.py migrate --run-syncdb 2>/dev/null || true
+cd "$PROJECT_ROOT"
+
+# ── 9. Verify installation ────────────────────────────────
+info ""
+info "═══════════════════════════════════════════════════"
+info "  Setup complete!"
+info "═══════════════════════════════════════════════════"
+info ""
+info "Installed packages:"
+pip list --format=columns | grep -iE "graph-visualizer|data-source|simple-visualizer|block-visualizer"
+info ""
+info "To start the application, run:"
+info "  ./run.sh django     (Django server on port 8000)"
+info "  ./run.sh flask      (Flask server on port 5001)"
+info ""
+info "To run tests:"
+info "  source venv/bin/activate"
+info "  pytest tests/ -v"
+info ""


### PR DESCRIPTION
Add automated setup and runner scripts for Ubuntu/Linux to streamline project installation and execution.

New files:
- requirements.txt: third-party dependencies (Django, Flask, rdflib, lxml, pytest)
- setup.sh: one-time environment setup — creates venv, installs all 7 components in editable mode, runs Django migrations
- run.sh: runner script with four modes:
  - django:    Django dev server on port 8000 (default)
  - flask:     Flask dev server on port 5001
  - test:      run pytest test suite
  - reinstall: clean and reinstall all components
  
  Closes #67 